### PR TITLE
Update .gitignore for IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # gradle
 .gradle/
 build/
+
+# IDEA
+.idea/
+EllaVator.iml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # EllaVator
+
+[![Join the chat at https://gitter.im/EllaVator/EllaVator](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/EllaVator/EllaVator?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
The upstream `opendial` branch is 2 commits behind `master`, which is inconsistent with our forks (we start `opendial` upon the newest commit in `master`). I synchronize the 2 commits and also update `.gitignore` for IDEA.